### PR TITLE
lib: Add Maps struct, impl Iterator for Maps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use std::fmt;
-use std::fs;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 use libc::pid_t;
@@ -23,7 +24,7 @@ static PSUEDO_PATH_MAP: phf::Map<&'static str, Pathname> = phf_map! {
 #[grammar = "map.pest"]
 struct MapParser;
 
-/// Represents the variants "pathname" field in a map.
+/// Represents the variants of the "pathname" field in a map.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub enum Pathname {
     Stack,
@@ -141,108 +142,140 @@ impl Default for Map {
     }
 }
 
+impl Map {
+    fn parse(line: &str) -> Result<Map, Error> {
+        // NOTE(ww): The map rule is singular, so this next + unwrap is safe after
+        // a successful parse.
+        let parsed = MapParser::parse(Rule::map, line)?.next().unwrap();
+        let mut map: Map = Default::default();
+
+        for entry in parsed.into_inner() {
+            match entry.as_rule() {
+                Rule::address_range => {
+                    let mut address_range = entry.into_inner();
+                    map.address_range.begin =
+                        u64::from_str_radix(address_range.next().unwrap().as_str(), 16)?;
+                    map.address_range.end =
+                        u64::from_str_radix(address_range.next().unwrap().as_str(), 16)?;
+                }
+                Rule::permissions => {
+                    let permissions = entry.as_str().as_bytes();
+
+                    map.permissions.readable = permissions[0] == b'r';
+                    map.permissions.writable = permissions[1] == b'w';
+                    map.permissions.executable = permissions[2] == b'x';
+                    map.permissions.shared = permissions[3] == b's';
+                    map.permissions.private = !map.permissions.shared;
+                }
+                Rule::offset => {
+                    let offset = entry.as_str();
+                    map.offset = u64::from_str_radix(offset, 16)?;
+                }
+                Rule::device => {
+                    let mut device = entry.into_inner();
+
+                    map.device.major = u64::from_str_radix(device.next().unwrap().as_str(), 16)?;
+                    map.device.minor = u64::from_str_radix(device.next().unwrap().as_str(), 16)?;
+                }
+                Rule::inode => {
+                    map.inode = entry.as_str().parse()?;
+                }
+                Rule::pathname => {
+                    let pathname = entry.as_str();
+
+                    if pathname.is_empty() {
+                        // An empty path indicates an mmap'd region.
+                        map.pathname = Pathname::Mmap;
+                    } else if PSUEDO_PATH_MAP.contains_key(pathname) {
+                        // There are some pseudo-files that we know; use their enum variants
+                        // if we see them.
+                        map.pathname = PSUEDO_PATH_MAP.get(pathname).unwrap().clone();
+                    } else if pathname.starts_with('[') && pathname.ends_with(']') {
+                        // There are probably other pseudo-files that we don't know;
+                        // if we see something that looks like one, mark it as such.
+                        map.pathname = Pathname::OtherPseudo(pathname.into());
+                    } else {
+                        // Finally, treat anything else like a path.
+                        // As proc(5) notes, there are a few ambiguities here with escaped
+                        // newlines and the "(deleted)" suffix; leave these to the user to figure out.
+                        map.pathname = Pathname::Path(pathname.into());
+                    }
+                }
+                // NOTE(ww): There are other rules, but we should never be able to match them in this context.
+                _ => {
+                    unreachable!();
+                }
+            }
+        }
+
+        Ok(map)
+    }
+}
+
+pub struct Maps<T: BufRead> {
+    reader: T,
+}
+
+impl<T: BufRead> Iterator for Maps<T> {
+    type Item = Result<Map, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut line_buf = String::new();
+        match self.reader.read_line(&mut line_buf) {
+            Ok(0) => None,
+            Ok(_) => {
+                // NOTE(ww): Annoying: the Lines iterator yields lines
+                // without their trailing delimiters, but read_line includes them.
+                if line_buf.ends_with('\n') {
+                    line_buf.pop();
+                }
+                Some(Map::parse(&line_buf))
+            }
+            Err(e) => Some(Err(e.into())),
+        }
+    }
+}
+
+impl<T: BufRead> Maps<T> {
+    pub fn new(reader: T) -> Maps<T> {
+        Maps { reader }
+    }
+}
+
 /// Returns a vector of maps for the given pid.
-pub fn from_pid(pid: pid_t) -> Result<Vec<Map>, Error> {
+pub fn from_pid(pid: pid_t) -> Result<Maps<BufReader<File>>, Error> {
     let path = Path::new("/proc").join(pid.to_string()).join("maps");
     from_path(&path)
 }
 
 /// Returns a vector of maps parsed from the given file.
-pub fn from_path(path: &Path) -> Result<Vec<Map>, Error> {
-    let maps_data = fs::read_to_string(path)?;
-    from_str(&maps_data)
+pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Maps<BufReader<File>>, Error> {
+    let reader = {
+        let f = File::open(path)?;
+        BufReader::new(f)
+    };
+
+    Ok(Maps::new(reader))
 }
 
 /// Returns a vector of maps parsed from the given string.
-pub fn from_str(maps_data: &str) -> Result<Vec<Map>, Error> {
-    let mut maps = Vec::new();
-
-    for line in maps_data.lines() {
-        let map = parse_map(line)?;
-        maps.push(map);
-    }
-
-    Ok(maps)
-}
-
-fn parse_map(line: &str) -> Result<Map, Error> {
-    // NOTE(ww): The map rule is singular, so this next + unwrap is safe after
-    // a successful parse.
-    let parsed = MapParser::parse(Rule::map, line)?.next().unwrap();
-    let mut map: Map = Default::default();
-
-    for entry in parsed.into_inner() {
-        match entry.as_rule() {
-            Rule::address_range => {
-                let mut address_range = entry.into_inner();
-                map.address_range.begin =
-                    u64::from_str_radix(address_range.next().unwrap().as_str(), 16)?;
-                map.address_range.end =
-                    u64::from_str_radix(address_range.next().unwrap().as_str(), 16)?;
-            }
-            Rule::permissions => {
-                let permissions = entry.as_str().as_bytes();
-
-                map.permissions.readable = permissions[0] == b'r';
-                map.permissions.writable = permissions[1] == b'w';
-                map.permissions.executable = permissions[2] == b'x';
-                map.permissions.shared = permissions[3] == b's';
-                map.permissions.private = !map.permissions.shared;
-            }
-            Rule::offset => {
-                let offset = entry.as_str();
-                map.offset = u64::from_str_radix(offset, 16)?;
-            }
-            Rule::device => {
-                let mut device = entry.into_inner();
-
-                map.device.major = u64::from_str_radix(device.next().unwrap().as_str(), 16)?;
-                map.device.minor = u64::from_str_radix(device.next().unwrap().as_str(), 16)?;
-            }
-            Rule::inode => {
-                map.inode = entry.as_str().parse()?;
-            }
-            Rule::pathname => {
-                let pathname = entry.as_str();
-
-                if pathname.is_empty() {
-                    // An empty path indicates an mmap'd region.
-                    map.pathname = Pathname::Mmap;
-                } else if PSUEDO_PATH_MAP.contains_key(pathname) {
-                    // There are some pseudo-files that we know; use their enum variants
-                    // if we see them.
-                    map.pathname = PSUEDO_PATH_MAP.get(pathname).unwrap().clone();
-                } else if pathname.starts_with('[') && pathname.ends_with(']') {
-                    // There are probably other pseudo-files that we don't know;
-                    // if we see something that looks like one, mark it as such.
-                    map.pathname = Pathname::OtherPseudo(pathname.into());
-                } else {
-                    // Finally, treat anything else like a path.
-                    // As proc(5) notes, there are a few ambiguities here with escaped
-                    // newlines and the "(deleted)" suffix; leave these to the user to figure out.
-                    map.pathname = Pathname::Path(pathname.into());
-                }
-            }
-            // NOTE(ww): There are other rules, but we should never be able to match them in this context.
-            _ => {
-                unreachable!();
-            }
-        }
-    }
-
-    Ok(map)
+pub fn from_str<'a>(maps_data: &'a str) -> Maps<&'a [u8]> {
+    Maps::new(maps_data.as_bytes())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::fs;
+
     use glob::glob;
     use serde_json;
 
     #[test]
     fn test_parse_map() {
         let map =
-            parse_map("5608dd391000-5608dd3be000 r--p 00000000 08:11 6572575 /bin/bash").unwrap();
+            Map::parse("5608dd391000-5608dd3be000 r--p 00000000 08:11 6572575 /bin/bash").unwrap();
 
         assert_eq!(map.address_range.begin, 0x5608dd391000);
         assert_eq!(map.address_range.end, 0x5608dd3be000);
@@ -271,13 +304,13 @@ mod tests {
             let maps_input = maps_input.unwrap();
             let reference_output = maps_input.with_extension("json");
 
-            let maps = from_path(&maps_input).unwrap();
+            let maps = from_path(&maps_input).unwrap().collect::<Vec<_>>();
             let expected_maps: Vec<Map> =
                 serde_json::from_str(&fs::read_to_string(reference_output).unwrap()).unwrap();
 
             assert_eq!(maps.len(), expected_maps.len());
             for (map, emap) in maps.iter().zip(expected_maps.iter()) {
-                assert_eq!(map, emap);
+                assert_eq!(map.as_ref().unwrap(), emap);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ impl Map {
     }
 }
 
+/// A wrapper structure for consuming individual `Map`s from a reader.
 pub struct Maps<T: BufRead> {
     reader: T,
 }
@@ -237,6 +238,7 @@ impl<T: BufRead> Iterator for Maps<T> {
 }
 
 impl<T: BufRead> Maps<T> {
+    /// Creates a new `Maps` from the given `reader`.
     pub fn new(reader: T) -> Maps<T> {
         Maps { reader }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,13 +242,13 @@ impl<T: BufRead> Maps<T> {
     }
 }
 
-/// Returns a vector of maps for the given pid.
+/// Returns an iterable `Maps` for the given pid.
 pub fn from_pid(pid: pid_t) -> Result<Maps<BufReader<File>>, Error> {
     let path = Path::new("/proc").join(pid.to_string()).join("maps");
     from_path(&path)
 }
 
-/// Returns a vector of maps parsed from the given file.
+/// Returns an iterable `Maps` parsed from the given file.
 pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Maps<BufReader<File>>, Error> {
     let reader = {
         let f = File::open(path)?;
@@ -258,7 +258,7 @@ pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Maps<BufReader<File>>, Error
     Ok(Maps::new(reader))
 }
 
-/// Returns a vector of maps parsed from the given string.
+/// Returns an iterable `Maps` parsed from the given string.
 pub fn from_str<'a>(maps_data: &'a str) -> Maps<&'a [u8]> {
     Maps::new(maps_data.as_bytes())
 }


### PR DESCRIPTION
Avoids the need to construct a Vec<Map> in memory.

Closes #3.