### PR TITLE
feat: add `from_lines` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,13 +125,6 @@ pub struct Device {
     pub minor: u64,
 }
 
-impl Device {
-    /// Returns the device's major and minor numbers as a single u64.
-    pub fn as_u64(&self) -> u64 {
-        (self.major << 20) | self.minor
-    }
-}
-
 impl fmt::Display for Device {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:02}-{:02}", self.major, self.minor)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,13 @@ pub struct Device {
     pub minor: u64,
 }
 
+impl Device {
+    /// Returns the device's major and minor numbers as a single u64.
+    pub fn as_u64(&self) -> u64 {
+        (self.major << 20) | self.minor
+    }
+}
+
 impl fmt::Display for Device {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:02}-{:02}", self.major, self.minor)


### PR DESCRIPTION
This was motivated by an existing use case: parsing jemalloc memory profiles, for example like in [rust-jemalloc-pprof](https://github.com/polarsignals/rust-jemalloc-pprof/blob/07bc78af6487af7b31d057e02d5fabd46a024c5f/pure/src/lib.rs#L260-L313). When parsing jemalloc memory profiles, the output of `/proc/self/maps` is included at the bottom of the file. Jemalloc profiles can be easily parsed using `.lines()`, so we already have a `Lines` data structure. 

Providing a `from_lines` method, like the `from_str` method, would make parsing the proc maps from the profile extremely easy. Let me know what you think!

This would be consumed like this:
```rust
    // Parse the mappings from the file
    let maps = rsprocmaps::from_lines(lines);
    for map in maps {
        let map = map?;
        // ...
    }
```